### PR TITLE
Fix when boundary tokens are the same

### DIFF
--- a/src/java/com/stratio/cassandra/index/RowMapperWide.java
+++ b/src/java/com/stratio/cassandra/index/RowMapperWide.java
@@ -207,6 +207,8 @@ public class RowMapperWide extends RowMapper
         if (!isSameToken) {
             Query rangeQuery = tokenMapper.query(startToken, stopToken, includeStart, includeStop);
             if (rangeQuery != null) query.add(rangeQuery, SHOULD);
+        } else if (query.getClauses().length == 0) {
+            return tokenMapper.query(startToken);
         }
 
         return query.getClauses().length == 0 ? null : query;


### PR DESCRIPTION
When DataRange boundary tokens are the same (i.e. isSameToken == true), startName and stopName are both empty. In this case the resulting query will be null which will lead to whole index search.
